### PR TITLE
Add Radia Perlman's Spanning Tree Protocol paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ A curated list of papers that may be of interest to Software Engineering student
     * The Design and Implementation of a Log-Structured File System. [Rosenblum, Ousterhout (1991)](https://people.eecs.berkeley.edu/~brewer/cs262/LFS.pdf).
 1. **A Protocol for Packet Network Intercommunication**. [Cerf, Kahn (1974)](https://www.cs.princeton.edu/courses/archive/fall06/cos561/papers/cerf74.pdf).
     * Ethernet: Distributed packet switching for local computer networks. [Metcalfe, Boggs (1978)](https://ethernethistory.typepad.com/papers/EthernetPaper.pdf).
+    * An algorithm for distributed computation of a Spanning Tree in an Extended LAN. [Perlman (1985)](https://dl.acm.org/doi/pdf/10.1145/319056.319004).
 1. **Programming with Abstract Data Types**. [Liskov, Zilles (1974)](https://dl.acm.org/doi/pdf/10.1145/942572.807045).
     * A Design Methodology for Reliable Software Systems. [Liskov (1972)](https://dl.acm.org/doi/pdf/10.1145/1479992.1480018).
     * The paradigms of programming. [Floyd (1979)](https://dl.acm.org/doi/pdf/10.1145/1283920.1283934).
@@ -176,6 +177,7 @@ A curated list of papers that may be of interest to Software Engineering student
 1. Reflections on Trusting Trust. [Thompson (1984)](https://www.cs.cmu.edu/~rdriley/487/papers/Thompson_1984_ReflectionsonTrustingTrust.pdf)
 1. Literate Programming. [Knuth (1984)](http://www.literateprogramming.com/knuthweb.pdf)
 1. Amortized Computational Complexity. [Tarjan (1985)](http://www.cs.duke.edu/courses/fall11/cps234/reading/Tarjan85_AmortizedComplexity.pdf)
+1. An algorithm for distributed computation of a Spanning Tree in an Extended LAN. [Perlman (1985)](https://dl.acm.org/doi/pdf/10.1145/319056.319004)
 1. On understanding types, data abstraction, and polymorphism. [Cardelli, Wegner (1985)](https://dl.acm.org/doi/pdf/10.1145/6041.6042)
 1. Programming as Theory Building. [Naur (1985)](https://pages.cs.wisc.edu/~remzi/Naur.pdf)
 1. Impossibility of Distributed Consensus With One Faulty Process. [Fisher, Lynch, Patterson (1985)](https://groups.csail.mit.edu/tds/papers/Lynch/jacm85.pdf)

--- a/papers.yml
+++ b/papers.yml
@@ -171,6 +171,10 @@
       author: Metcalfe, Boggs
       year: 1978
       link: https://ethernethistory.typepad.com/papers/EthernetPaper.pdf
+    - title: An algorithm for distributed computation of a Spanning Tree in an Extended LAN
+      author: Perlman
+      year: 1985
+      link: https://dl.acm.org/doi/pdf/10.1145/319056.319004
 
 - title: Programming with Abstract Data Types
   author: Liskov, Zilles
@@ -459,7 +463,3 @@
   author: Gregg
   year: 2012
   link: https://queue.acm.org/detail.cfm?id=2413037
-- title: "An algorithm for distributed computation of a Spanning Tree in an Extended LAN"
-  author: Perlman
-  year: 1985
-  link: https://dl.acm.org/doi/pdf/10.1145/319056.319004


### PR DESCRIPTION
This PR adds the following changes:

- Radia Perlman's "[An algorithm for distributed computation of a Spanning Tree in an Extended LAN](https://dl.acm.org/doi/abs/10.1145/319056.319004)" paper

[Ricardo Martins](https://github.com/meqif) mentioned that [this is a very important paper in the computer networking space](https://en.wikipedia.org/wiki/Radia_Perlman#Spanning_Tree_Protocol) and so I'm proposing adding it to the list.